### PR TITLE
Small readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Click anywhere on the scene to capture the mouse again.
 ```bash
 # Clone the repo
 git clone git@github.com:goncalooliveirasilva/a-little-walk.git
-cd ua-icg
+cd a-little-walk/
 
 # Install dependencies
 npm install


### PR DESCRIPTION
This pull request updates the setup instructions in the `README.md` file to correct the directory name when cloning the repository. This ensures that users follow the correct steps after cloning the repo.

* Updated the `cd` command in the setup instructions to use the correct directory name (`a-little-walk/`) instead of the previous incorrect name (`ua-icg`).